### PR TITLE
Feature sct compose

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,11 @@ sqlwhat
 Api
 ----
 
+Syntax
+~~~~~~
+
+.. autofunction:: sqlwhat.sct_syntax.Ex
+
 Check query results
 ~~~~~~~~~~~~~~~~~~~
 

--- a/sqlwhat/checks/__init__.py
+++ b/sqlwhat/checks/__init__.py
@@ -1,3 +1,3 @@
 from sqlwhat.checks.check_result import check_result, test_has_columns, test_nrows, test_ncols, test_column, allow_error, test_error, test_name_miscased
-from sqlwhat.checks.check_logic import fail, multi, test_or, test_correct
+from sqlwhat.checks.check_logic import fail, multi, extend, test_or, test_correct
 from sqlwhat.checks.check_funcs import check_node, check_field, test_student_typed, has_equal_ast, test_mc, success_msg, verify_ast_parses

--- a/sqlwhat/checks/check_logic.py
+++ b/sqlwhat/checks/check_logic.py
@@ -44,6 +44,18 @@ def multi(state, *args):
     # return original state, so can be chained
     return state
 
+def extend(state, *args):
+    for arg in args:
+        # when input is a single test, make iterable
+        if callable(arg): arg = [arg]
+
+        for test in arg:
+            # update state to be output of current test
+            state = test(state)
+
+    # return original state, so can be chained
+    return state
+
 def test_or(state, *tests):
     """Test whether at least one SCT passes.
     

--- a/sqlwhat/sct_syntax.py
+++ b/sqlwhat/sct_syntax.py
@@ -21,24 +21,41 @@ class Chain:
         self._crnt_sct = None
         self._waiting_on_call = False
 
+    def _double_attr_error(self):
+        raise AttributeError("Did you forget to call a statement? "
+                                "e.g. Ex().check_list_comp.check_body()")
+
     def __getattr__(self, attr):
         if attr not in ATTR_SCTS: raise AttributeError("No SCT named %s"%attr)
-        elif self._waiting_on_call: 
-            raise AttributeError("Did you forget to call a statement? "
-                                 "e.g. Ex().check_list_comp.check_body()")
+        elif self._waiting_on_call: self._double_attr_error()
         else:
             # make a copy to return, 
             # in case someone does: a = chain.a; b = chain.b
-            chain = copy.copy(self)
-            chain._crnt_sct = ATTR_SCTS[attr]
-            chain._waiting_on_call = True
-            return chain
+            return self._sct_copy(ATTR_SCTS[attr])
 
     def __call__(self, *args, **kwargs):
         # NOTE: the only change from python what is that state is now 1st pos arg below
         self._state = self._crnt_sct(self._state, *args, **kwargs)
         self._waiting_on_call = False
         return self
+
+    def __add__(self, f):
+        if self._waiting_on_call:
+            self._double_attr_error()
+        elif type(f) == Chain:
+            raise BaseException("did you use a result of the Ex() function on the right hand side of the + operator?")
+        elif not callable(f):
+            raise BaseException("right hand side of + operator should be an SCT, so must be callable!")
+        else:
+            chain = self._sct_copy(f)
+            return chain()
+
+    def _sct_copy(self, f):
+        chain = copy.copy(self)
+        chain._crnt_sct = f
+        chain._waiting_on_call = True
+        return chain
+            
 
 
 class F(Chain):
@@ -54,7 +71,7 @@ class F(Chain):
         else:
             call_data = (self._crnt_sct, args, kwargs)
             return self.__class__(self._stack + [call_data])
-    
+
     @staticmethod
     def _call_from_data(f, args, kwargs, state):
         return f(state, *args, **kwargs)

--- a/sqlwhat/sct_syntax.py
+++ b/sqlwhat/sct_syntax.py
@@ -123,3 +123,4 @@ ATTR_SCTS = {k: v for k,v in vars(checks).items() if k not in builtins.__dict__ 
 SCT_CTX = {k: state_dec(v) for k,v in ATTR_SCTS.items()}
 SCT_CTX['Ex'] = Ex
 SCT_CTX['F'] = F
+SCT_CTX['state_dec'] = state_dec

--- a/sqlwhat/sct_syntax.py
+++ b/sqlwhat/sct_syntax.py
@@ -39,7 +39,7 @@ class Chain:
         self._waiting_on_call = False
         return self
 
-    def __add__(self, f):
+    def __rshift__(self, f):
         if self._waiting_on_call:
             self._double_attr_error()
         elif type(f) == Chain:
@@ -78,6 +78,7 @@ class F(Chain):
 
     @classmethod
     def _from_func(cls, f, *args, **kwargs):
+        """Creates a function chain starting with the specified SCT (f), and its arguments."""
         func_chain = cls()
         func_chain._stack.append([f, args, kwargs])
         return func_chain
@@ -109,6 +110,14 @@ def Ex(state=None):
 
             # life writing SCTs on DataCamp.com
             Ex().test_student_typed(text="SELECT id")
+            
+        Further, note that the operator ``>>`` can be used in place of chaining.::
+
+            # Ex with chaining
+            Ex().test_student_typed(text="SELECT id")
+
+            # Ex without
+            Ex() >> test_student_typed(text="SELECT id")
             
     """
     return Chain(state or State.root_state)

--- a/sqlwhat/tests/test_check_logic.py
+++ b/sqlwhat/tests/test_check_logic.py
@@ -24,6 +24,8 @@ def fails(state, msg=""):
 
 def passes(state): return state
 
+def childx(state): return state.to_child(student_code = state.student_code + 'x')
+
 @pytest.mark.parametrize('arg1', ( passes, [passes, passes] ))
 @pytest.mark.parametrize('arg2', ( passes, [passes, passes] ))
 def test_test_multi_pass_one(state, arg1, arg2):
@@ -36,6 +38,19 @@ def test_test_multi_fail_arg1(state, arg1):
 @pytest.mark.parametrize('arg2', ( fails, [passes, fails] ))
 def test_test_multi_fail_arg2(state, arg2):
     with pytest.raises(TF): cl.multi(state, passes, arg2)
+
+@pytest.mark.parametrize('sct,stu_code,is_star_args', [
+    (childx, 'x', False),
+    ([childx, childx], 'xx', False),
+    ([childx, childx], 'xx', True),
+    ([[childx, childx], childx], 'xxx', True)
+    ])
+def test_extend(state, sct, stu_code, is_star_args):
+    child = cl.extend(state, sct) if not is_star_args else cl.extend(state, *sct)
+    assert child.student_code == stu_code
+
+def test_extend_fail(state):
+    with pytest.raises(TF): cl.extend(state, childx, lambda state: cl.fail(state))
 
 def test_test_or_pass(state):
     cl.test_or(state, passes, fails)

--- a/sqlwhat/tests/test_sct_syntax.py
+++ b/sqlwhat/tests/test_sct_syntax.py
@@ -1,0 +1,77 @@
+from sqlwhat.sct_syntax import Ex, F, state_dec
+import pytest
+
+@pytest.fixture
+def addx():
+    return lambda state, x: state + x
+
+@pytest.fixture
+def f():
+    return F._from_func(lambda state, b: state + b, b = 'b')
+
+@pytest.fixture
+def f2():
+    return F._from_func(lambda state, c: state + c, c = 'c')
+
+def test_f_from_func(f):
+    assert f('a') == 'ab'
+
+def test_f_sct_copy_kw(addx):
+    assert F()._sct_copy(addx)(x = 'x')('state') == 'statex'
+
+def test_f_sct_copy_pos(addx):
+    assert F()._sct_copy(addx)('x')('state') == 'statex'
+
+def test_ex_sct_copy_kw(addx):
+    assert Ex('state')._sct_copy(addx)(x = 'x')._state == 'statex'
+
+def test_ex_sct_copy_pos(addx):
+    assert Ex('state')._sct_copy(addx)('x')._state == 'statex'
+
+def test_f_2_funcs(f, addx):
+    g = f._sct_copy(addx)
+    
+    assert g(x = 'x')('a') == 'abx'
+
+def test_f_add_unary_func(f):
+    g = f + (lambda state: state + 'c')
+    assert g('a') == 'abc'
+
+def test_f_add_f(f, f2):
+    g = f + f2
+    assert g('a') == 'abc'
+
+def test_f_from_state_dec(addx):
+    dec_addx = state_dec(addx)
+    f = dec_addx(x = 'x')
+    isinstance(f, F)
+    assert f('state') == 'statex'
+
+@pytest.fixture
+def ex():
+    return Ex('state')._sct_copy(lambda state, x: state + x)('x')
+
+def test_ex_add_f(ex, f):
+    (ex + f)._state = 'statexb'
+
+def test_ex_add_unary(ex):
+    (ex + (lambda state: state + 'b'))._state == 'statexb'
+
+def test_ex_add_ex_err(ex):
+    with pytest.raises(BaseException): ex + ex
+
+def test_f_add_ex_err(f, ex):
+    with pytest.raises(BaseException): f + ex
+
+
+from sqlwhat.State import State
+from sqlwhat.Reporter import Reporter
+def test_state_dec_instant_eval():
+    state = State("student_code", "", "", None, None, {}, {}, Reporter())
+
+    @state_dec
+    def stu_code(state, x = 'x'):
+        return state.student_code + x
+
+    assert stu_code(state) == "student_codex"
+

--- a/sqlwhat/tests/test_sct_syntax.py
+++ b/sqlwhat/tests/test_sct_syntax.py
@@ -34,11 +34,11 @@ def test_f_2_funcs(f, addx):
     assert g(x = 'x')('a') == 'abx'
 
 def test_f_add_unary_func(f):
-    g = f + (lambda state: state + 'c')
+    g = f >> (lambda state: state + 'c')
     assert g('a') == 'abc'
 
 def test_f_add_f(f, f2):
-    g = f + f2
+    g = f >> f2
     assert g('a') == 'abc'
 
 def test_f_from_state_dec(addx):
@@ -52,16 +52,16 @@ def ex():
     return Ex('state')._sct_copy(lambda state, x: state + x)('x')
 
 def test_ex_add_f(ex, f):
-    (ex + f)._state = 'statexb'
+    (ex >> f)._state = 'statexb'
 
 def test_ex_add_unary(ex):
-    (ex + (lambda state: state + 'b'))._state == 'statexb'
+    (ex >> (lambda state: state + 'b'))._state == 'statexb'
 
 def test_ex_add_ex_err(ex):
-    with pytest.raises(BaseException): ex + ex
+    with pytest.raises(BaseException): ex >> ex
 
 def test_f_add_ex_err(f, ex):
-    with pytest.raises(BaseException): f + ex
+    with pytest.raises(BaseException): f >> ex
 
 
 from sqlwhat.State import State


### PR DESCRIPTION
Allows composition over SCT functions, via the `+` operator. **Note that I'm putting this here so we can discuss the idea.** Other operators, such as `>` or `>>` are available (and have been used to do similar things in other libraries).

E.g.

```
sel = Ex().check_node("SelectStmt")
tv = check_field("target_value")

# combine
sel + tv

# equivalent to
sel.extend(tv)

# equivalent to 
Ex().check_node("SelectStmt").check_field("target_value")

# similar to below (except multi doesn't return the child state from tv)
sel.multi(tv)

# could also do the following, since tv is just an F instance
sel + tv.has_equal_ast()
```