### PR TITLE
Feature speaker

### DIFF
--- a/sqlwhat/Reporter.py
+++ b/sqlwhat/Reporter.py
@@ -42,7 +42,7 @@ class Reporter(object):
                 if highlight: 
                     self.feedback = Feedback(self.feedback.message, highlight)
 
-                raise TestFail
+                raise TestFail(self.feedback)
 
         else: 
             result = None

--- a/sqlwhat/checks/check_funcs.py
+++ b/sqlwhat/checks/check_funcs.py
@@ -215,8 +215,8 @@ def has_equal_ast(state,
     sol_rep = repr(sol_ast)
 
     _msg = state.ast_dispatcher.describe(state.student_ast, msg)
-    if       exact and (sol_rep != stu_rep):     state.do_test(Test(_msg))
-    elif not exact and (sol_rep not in stu_rep): state.do_test(Test(_msg))
+    if       exact and (sol_rep != stu_rep):     state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
+    elif not exact and (sol_rep not in stu_rep): state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
 
     return state
 

--- a/sqlwhat/checks/check_funcs.py
+++ b/sqlwhat/checks/check_funcs.py
@@ -63,8 +63,11 @@ def check_node(state, name, index=0, missing_msg="Could not find the {index}{nod
         _msg = state.ast_dispatcher.describe(sol_stmt, missing_msg, index = index)
         state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
 
+    action = {'type': 'check_node', 'kwargs': {'name': name, 'index': index}, 'node': stu_stmt}
+    
+    return state.to_child(student_ast = stu_stmt, solution_ast = sol_stmt,
+                          history = state.history + (action,)) 
 
-    return state.to_child(student_ast = stu_stmt, solution_ast = sol_stmt)
 
 @requires_ast
 def check_field(state, name, index=None, missing_msg="Could not find the {index}{field_name} of the {node_name}."):
@@ -112,7 +115,10 @@ def check_field(state, name, index=None, missing_msg="Could not find the {index}
         _msg = state.ast_dispatcher.describe(state.student_ast, missing_msg, field = name, index = index)
         state.do_test(Test(_msg))
 
-    return state.to_child(student_ast = stu_attr, solution_ast = sol_attr)
+    action = {'type': 'check_field', 'kwargs': {'name': name, 'index': index}}
+
+    return state.to_child(student_ast = stu_attr, solution_ast = sol_attr,
+                          history = state.history + (action,)) 
 
 import re
 
@@ -177,7 +183,7 @@ def test_student_typed(state, text, msg="Submission does not contain the code `{
 
 @requires_ast
 def has_equal_ast(state, 
-                  msg="Check the {node_name}. Your code does not seem to match the solution.",
+                  msg="Check the {ast_path}. Your code does not seem to match the solution.",
                   sql=None,
                   start="sql_script",
                   exact=True):
@@ -214,7 +220,7 @@ def has_equal_ast(state,
     stu_rep = repr(state.student_ast)
     sol_rep = repr(sol_ast)
 
-    _msg = state.ast_dispatcher.describe(state.student_ast, msg)
+    _msg = state.ast_dispatcher.describe(state.student_ast, msg, ast_path = state.get_ast_path())
     if       exact and (sol_rep != stu_rep):     state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
     elif not exact and (sol_rep not in stu_rep): state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
 

--- a/sqlwhat/checks/check_funcs.py
+++ b/sqlwhat/checks/check_funcs.py
@@ -220,7 +220,7 @@ def has_equal_ast(state,
     stu_rep = repr(state.student_ast)
     sol_rep = repr(sol_ast)
 
-    _msg = state.ast_dispatcher.describe(state.student_ast, msg, ast_path = state.get_ast_path())
+    _msg = msg.format(ast_path = state.get_ast_path())
     if       exact and (sol_rep != stu_rep):     state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
     elif not exact and (sol_rep not in stu_rep): state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
 

--- a/sqlwhat/checks/check_funcs.py
+++ b/sqlwhat/checks/check_funcs.py
@@ -4,6 +4,8 @@ from sqlwhat.State import State
 from functools import partial, wraps
 import copy
 
+MSG_CHECK_FALLBACK = "Your submission is incorrect. Try again!"
+
 def requires_ast(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
@@ -19,7 +21,7 @@ def requires_ast(f):
     return wrapper
 
 @requires_ast
-def check_node(state, name, index=0, missing_msg="Your submission is incorrect. Try again!", priority=None):
+def check_node(state, name, index=0, missing_msg="Could not find the {index} {node_name}.", priority=None):
     """Select a node from abstract syntax tree (AST), using its name and index position.
     
     Args:
@@ -50,20 +52,22 @@ def check_node(state, name, index=0, missing_msg="Your submission is incorrect. 
     """
     df = partial(state.ast_dispatcher, 'node', name, slice(None), priority=priority)
 
-    stu_stmt_list = df(state.student_ast)
-    try: stu_stmt = stu_stmt_list[index]
-    except IndexError: 
-        _msg = missing_msg.format(name)
-        state.do_test(Test(_msg))
-
     sol_stmt_list = df(state.solution_ast) 
     try: sol_stmt = sol_stmt_list[index]
     except IndexError: raise IndexError("Can't get %s statement at index %s"%(name, index))
 
+    stu_stmt_list = df(state.student_ast)
+    try: stu_stmt = stu_stmt_list[index]
+    except IndexError: 
+        # use speaker on ast dialect module to get message, or fall back to generic
+        _msg = state.ast_dispatcher.describe(sol_stmt, missing_msg, index = index)
+        state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
+
+
     return state.to_child(student_ast = stu_stmt, solution_ast = sol_stmt)
 
 @requires_ast
-def check_field(state, name, index=None, missing_msg="Your submission is incorrect. Try again!"):
+def check_field(state, name, index=None, missing_msg="Could not find the {index} entry in the {field_name} of the {node_name}."):
     """Select an attribute from an abstract syntax tree (AST) node, using the attribute name.
     
     Args:
@@ -93,8 +97,9 @@ def check_field(state, name, index=None, missing_msg="Your submission is incorre
         stu_attr = getattr(state.student_ast, name)
         if index is not None: stu_attr = stu_attr[index]
     except: 
-        _msg = missing_msg.format(name)
-        state.do_test(Test(_msg))
+        # use speaker on ast dialect module to get message, or fall back to generic
+        _msg = state.ast_dispatcher.describe(state.student_ast, missing_msg, field = name, index = index)
+        state.do_test(Test(_msg or MSG_CHECK_FALLBACK))
 
     try: 
         sol_attr = getattr(state.solution_ast, name)
@@ -171,7 +176,11 @@ def test_student_typed(state, text, msg="Submission does not contain the code `{
 
 
 @requires_ast
-def has_equal_ast(state, msg="Your submission is incorrect. Try again!", sql=None, start="sql_script", exact=True):
+def has_equal_ast(state, 
+                  msg="Check the {node_name}. Your code does not seem to match the solution.",
+                  sql=None,
+                  start="sql_script",
+                  exact=True):
     """Test whether the student and solution code have identical AST representations
 
     Args:
@@ -205,8 +214,9 @@ def has_equal_ast(state, msg="Your submission is incorrect. Try again!", sql=Non
     stu_rep = repr(state.student_ast)
     sol_rep = repr(sol_ast)
 
-    if       exact and (sol_rep != stu_rep):     state.do_test(Test(msg))
-    elif not exact and (sol_rep not in stu_rep): state.do_test(Test(msg))
+    _msg = state.ast_dispatcher.describe(state.student_ast, msg)
+    if       exact and (sol_rep != stu_rep):     state.do_test(Test(_msg))
+    elif not exact and (sol_rep not in stu_rep): state.do_test(Test(_msg))
 
     return state
 

--- a/sqlwhat/selectors.py
+++ b/sqlwhat/selectors.py
@@ -80,6 +80,14 @@ class Dispatcher:
             if self.safe_parsing: return e
             else: raise e
 
+    def describe(self, node, msg, field = "", **kwargs):
+        speaker = getattr(self.ast, 'speaker', None)
+
+        if 'index' in kwargs: kwargs['index'] = get_ord(kwargs['index'] + 1)
+        if speaker:
+            return self.ast.speaker.describe(node, field = field, 
+                                             fmt = msg, **kwargs)
+
     @staticmethod
     def get(nodes, predicate, map_name = lambda x: x):
         return {map_name(k): v for k, v in nodes.items() if predicate(k, v)}
@@ -116,3 +124,13 @@ def lower_case(f):
         return f(*args, **kwargs).lower()
     return wrapper
 
+
+def get_ord(num):
+    assert num != 0, "use strictly positive numbers in get_ord()"
+    nums = {1: "first", 2: "second", 3:"third", 4:"fourth",
+            5: "fifth", 6: "sixth", 7:"seventh", 8:"eight",
+            9: "nineth", 10: "tenth"}
+    if num in nums:
+        return(nums[num])
+    else:
+        return("%dth" % num)

--- a/sqlwhat/selectors.py
+++ b/sqlwhat/selectors.py
@@ -135,7 +135,7 @@ def get_ord(num):
     assert num != 0, "use strictly positive numbers in get_ord()"
     nums = {1: "first", 2: "second", 3:"third", 4:"fourth",
             5: "fifth", 6: "sixth", 7:"seventh", 8:"eight",
-            9: "nineth", 10: "tenth"}
+            9: "ninth", 10: "tenth"}
     if num in nums:
         return(nums[num])
     else:

--- a/sqlwhat/selectors.py
+++ b/sqlwhat/selectors.py
@@ -85,7 +85,7 @@ class Dispatcher:
 
         has_index = kwargs.get('index') is not None
         if has_index: 
-            phrase = "{} entry of " if field else "the {} "
+            phrase = "{} entry in the " if field else "{} "
             kwargs['index'] = phrase.format(get_ord(kwargs['index'] + 1))
         else: 
             kwargs['index'] = ""

--- a/sqlwhat/selectors.py
+++ b/sqlwhat/selectors.py
@@ -83,7 +83,13 @@ class Dispatcher:
     def describe(self, node, msg, field = "", **kwargs):
         speaker = getattr(self.ast, 'speaker', None)
 
-        if 'index' in kwargs: kwargs['index'] = get_ord(kwargs['index'] + 1)
+        has_index = kwargs.get('index') is not None
+        if has_index: 
+            phrase = "{} entry of " if field else "the {} "
+            kwargs['index'] = phrase.format(get_ord(kwargs['index'] + 1))
+        else: 
+            kwargs['index'] = ""
+
         if speaker:
             return self.ast.speaker.describe(node, field = field, 
                                              fmt = msg, **kwargs)

--- a/sqlwhat/tests/test_check_funcs.py
+++ b/sqlwhat/tests/test_check_funcs.py
@@ -195,3 +195,10 @@ def test_verify_ast_parses_fail():
     state_tst = prepare_state("SELECT * FROM x!!!", "SELECT * FROM x!!!")
     with pytest.raises(TF):
         cf.verify_ast_parses(state_tst)
+
+def test_check_field_index_none_fail():
+    state = prepare_state("SELECT a, b FROM b WHERE a < 10", "SELECT a FROM b")
+    sel = check_node(state, 'SelectStmt') 
+    with pytest.raises(TF) as exc_info:
+        from_field = check_field(sel, 'where_clause')
+    print_message(exc_info)

--- a/sqlwhat/tests/test_check_funcs.py
+++ b/sqlwhat/tests/test_check_funcs.py
@@ -6,6 +6,8 @@ from sqlwhat.Reporter import Reporter
 from sqlwhat.Test import TestFail as TF
 import pytest
 
+def print_message(exc): print(exc.value.args[0].message)
+
 @pytest.fixture
 def ast_mod():
     return get_ast_parser('postgresql')
@@ -45,7 +47,8 @@ def test_has_equal_ast_pass_unparsed():
 
 def test_has_equal_ast_fail_quoted_column():
     state = prepare_state('SELECT "id", "name" FROM "Trips"', "SELECT id, name FROM Trips")
-    with pytest.raises(TF): has_equal_ast(state=state)
+    with pytest.raises(TF) as exc_info: has_equal_ast(state=state)
+    print_message(exc_info)
 
 def test_has_equal_ast_manual_fail():
     query = "SELECT id, name FROM Trips"
@@ -70,8 +73,9 @@ def test_has_equal_ast_not_exact_fail():
     query = "SELECT id, name FROM Trips WHERE id < 100 AND name = 'greg'"
     state = prepare_state(query, query)
     child = check_node(state, "SelectStmt")
-    with pytest.raises(TF):
+    with pytest.raises(TF) as exc_info:
         has_equal_ast(child, sql="id < 999", start="expression", exact=False)
+    print_message(exc_info)
 
 def test_check_node_pass(ast_mod):
     state = prepare_state("SELECT id, name FROM Trips", "SELECT id FROM Trips")
@@ -81,7 +85,8 @@ def test_check_node_pass(ast_mod):
 
 def test_check_node_fail():
     state = prepare_state("SELECT id, name FROM Trips", "INSERT INTO Trips VALUES (1)")
-    with pytest.raises(TF): check_node(state, "SelectStmt", 0)
+    with pytest.raises(TF) as exc_info: check_node(state, "SelectStmt", 0)
+    print_message(exc_info)
 
 def test_check_node_priority_pass(ast_mod):
     state = prepare_state("SELECT id, name FROM Trips", "SELECT id FROM Trips")
@@ -90,9 +95,10 @@ def test_check_node_priority_pass(ast_mod):
     assert isinstance(child.solution_ast, ast_mod.Identifier)
 
 def test_check_node_priority_fail():
-    state = prepare_state("SELECT id, name FROM Trips", "INSERT INTO Trips VALUES (1)")
-    with pytest.raises(TF): check_node(state, "SelectStmt", 0, priority=0)
-    with pytest.raises(TF): check_node(state, "Identifier", 0)
+    state = prepare_state("SELECT id + 1, name FROM Trips", "INSERT INTO Trips VALUES (1)")
+    with pytest.raises(TF):             check_node(state, "SelectStmt", 0, priority=0)
+    with pytest.raises(TF) as exc_info: check_node(state, "BinaryExpr", 0, priority = 99)
+    print_message(exc_info)
 
 def test_check_node_back_to_back():
     state = prepare_state("SELECT 1 + 2 + 3 FROM x", "SELECT 1 + 2 + 3 FROM x")
@@ -131,7 +137,8 @@ def test_check_field_index_pass():
 def test_check_field_index_fail():
     state = prepare_state("SELECT id, name FROM Trips", "SELECT id FROM Trips")
     select = check_node(state, "SelectStmt", 0)
-    with pytest.raises(TF): check_field(select, "target_list", 1)
+    with pytest.raises(TF) as exc_info: check_field(select, "target_list", 1)
+    print_message(exc_info)
 
 
 def test_check_field_antlr_exception_skips(dialect_name):

--- a/sqlwhat/tests/test_check_funcs.py
+++ b/sqlwhat/tests/test_check_funcs.py
@@ -50,6 +50,13 @@ def test_has_equal_ast_fail_quoted_column():
     with pytest.raises(TF) as exc_info: has_equal_ast(state=state)
     print_message(exc_info)
 
+def test_has_equal_ast_field_fail():
+    state = prepare_state('SELECT id, name FROM Trips', "SELECT name FROM Trips")
+    sel = cf.check_node(state, "SelectStmt", 0)
+    tl = cf.check_field(sel, "target_list", 0)
+    with pytest.raises(TF) as exc_info: has_equal_ast(tl)
+    print_message(exc_info)
+
 def test_has_equal_ast_manual_fail():
     query = "SELECT id, name FROM Trips"
     state = prepare_state(query, query)


### PR DESCRIPTION
This addresses #34. Note that for `has_equal_ast` I opted for 

"Check the {index number} in the {field_name} of your {node_name}.", 

which doesn't describe the student's current node, but is a bit less verbose. You can run `py.test -m "not backend" -s` to see printed feedback messages.