### PR TITLE
make decorated scts importable from sct_syntax

### DIFF
--- a/sqlwhat/sct_syntax.py
+++ b/sqlwhat/sct_syntax.py
@@ -130,6 +130,9 @@ import builtins
 ATTR_SCTS = {k: v for k,v in vars(checks).items() if k not in builtins.__dict__ if not k.startswith('__')}
 # used in test_exercise, so that scts without Ex() don't run immediately
 SCT_CTX = {k: state_dec(v) for k,v in ATTR_SCTS.items()}
+globals().update(SCT_CTX)
 SCT_CTX['Ex'] = Ex
 SCT_CTX['F'] = F
 SCT_CTX['state_dec'] = state_dec
+# put on module for easy importing
+__all__ = list(SCT_CTX.keys())


### PR DESCRIPTION
relatively minor--shouldn't affect existing code. Allows

```
from sqlwhat.sct_syntax import *
```

To import the special forms of SCTs that allow them to not need a state argument. Like `test_student_typed` below..

`Ex().test_correct(something, test_student_typed(...))`