### PR TITLE
fix typo causing all mssql scts to fail

### DIFF
--- a/sqlwhat/State.py
+++ b/sqlwhat/State.py
@@ -35,6 +35,7 @@ class State(BaseState):
         #       detremental to DataCamp courses. Need to move to more sane configuration.
 #        if dialect_name == 'mssql':
         if dialect == 'mssql':
-            ast_dispatcher.ast.AstNode.__repr__ = lower_case(ast_parser.AstNode.__repr__)
+            AstNode = ast_dispatcher.ast.AstNode
+            AstNode.__repr__ = lower_case(AstNode.__repr__)
 
         return ast_dispatcher

--- a/sqlwhat/tests/test_state.py
+++ b/sqlwhat/tests/test_state.py
@@ -16,7 +16,7 @@ def test_pass(conn):
         pre_exercise_code = "",
         student_result =  {'id': [1], 'name': ['greg']},
         solution_result = {'id': [1], 'name': ['greg']},
-        student_conn = Connection('postgresql'),
+        student_conn = conn,
         solution_conn = None,
         reporter= Reporter())
 
@@ -31,7 +31,7 @@ def test_fail(conn):
         pre_exercise_code = "",
         student_result = {'id': [1], 'name': ['greg']},
         solution_result = {'id': [0], 'name': ['greg']},
-        student_conn = Connection('postgresql'),
+        student_conn = conn,
         solution_conn = None,
         reporter= Reporter())
 


### PR DESCRIPTION
Accidentally referred to variable that didn't exist AND the unit test that should have detected this had a slight error (so tested only postgres). :( 