### PR TITLE
test_not

### DIFF
--- a/sqlwhat/checks/__init__.py
+++ b/sqlwhat/checks/__init__.py
@@ -1,5 +1,5 @@
 from sqlwhat.checks.check_result import check_result, test_has_columns, test_nrows, test_ncols, test_column, allow_error, test_error, test_name_miscased, test_column_name, sort_rows
 
 from protowhat.checks.check_funcs import check_node, check_field, test_student_typed, has_equal_ast, verify_ast_parses
-from protowhat.checks.check_logic import fail, multi, extend, test_or, test_correct
+from protowhat.checks.check_logic import fail, multi, test_not, extend, test_or, test_correct
 from protowhat.checks.check_simple import test_mc, success_msg

--- a/sqlwhat/tests/test_basic.py
+++ b/sqlwhat/tests/test_basic.py
@@ -53,6 +53,7 @@ xfail_def = pytest.mark.xfail(reason="implement deferrel")
     "Ex().test_or(test_student_typed('SELECT'))",
     "Ex().test_correct(test_student_typed('SELECT'), test_student_typed('SEL'))",
     "Ex().test_correct(test_student_typed('SELECT'), test_student_typed('SEL').test_student_typed('SEL'))",
+    "Ex().test_not(test_student_typed('WHERE'), msg='do not write WHERE')",
     "Ex().check_result()",
     "Ex().test_has_columns()",
     "Ex().test_nrows()",


### PR DESCRIPTION
Import and integration-test test_not functionality coming from protowhat.
This branch fails because the PR hasn't been merged in on the protowhat side, and I'm not explicitly telling travis to install a dev version of protowhat.
It works locally though, if you have the appropriate version of protowhat installed.