### PR TITLE
Add force_diagnose to test_exercise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pkg deps
-protowhat==1.2.0
+protowhat==1.3.0
 antlr-plsql==0.6.1
 antlr-tsql==0.10.1
 

--- a/sqlwhat/test_exercise.py
+++ b/sqlwhat/test_exercise.py
@@ -13,6 +13,7 @@ def test_exercise(sct,
                   pre_exercise_code,
                   ex_type,
                   error,
+                  force_diagnose = False,
                   debug = False   # currently unused
                   ):
     """
@@ -26,7 +27,8 @@ def test_exercise(sct,
         solution_conn = solution_conn,
         student_result = student_result,
         solution_result = solution_result,
-        reporter = Reporter(error))
+        reporter = Reporter(error),
+        force_diagnose = force_diagnose)
 
     SCT_CTX['Ex'].root_state = state
 


### PR DESCRIPTION
Support datacamp/exercise-validator/issues/158 by accepting the `force_diagnose` parameter.
Depends on datacamp/protowhat/pull/28
Depends on datacamp/sqlwhat#132